### PR TITLE
fixed floatToDF according to TI datasheet

### DIFF
--- a/BQ35100.cpp
+++ b/BQ35100.cpp
@@ -1362,7 +1362,7 @@ void BQ35100::floatToDF(float val, char *result) {
     } else if (tmp_val >= 1.0) {
         while (tmp_val >= 1.0) {
             tmp_val /= 2;
-            exp--;
+            exp++;
         }
     }
 


### PR DESCRIPTION
This function to compute custom float representation has a flaw, respect to TI datasheet  check TRM, chapter 3.10 (https://www.ti.com/lit/ug/sluubh1c/sluubh1c.pdf?ts=1681739706960&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252FBQ35100%253FkeyMatch%253DBQ35100%2526tisearch%253Dsearch-everything%2526usecase%253DGPN)

As an effect, without this fix, numbers as 2^-20 and 2^18 are represented the same (00 00 00 6D)